### PR TITLE
feat: resolve secrets via 1Password CLI with Keychain fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,17 +112,29 @@ path is otherwise silent so it stays script-composable (`token="$(get-secret NAM
 
 #### Migrating existing Keychain secrets to 1Password
 
-Run once, interactively, by hand:
+`secret-migrate` (also in `utils.sh`) migrates one or more named secrets from Keychain
+into 1Password. Run it interactively, by hand, whenever you need to migrate something:
 
 ```bash
-./bin/migrate-secrets-to-1password.sh
+secret-migrate CLICKUP_API_TOKEN SLITE_API_TOKEN
 ```
 
+Or use the bin wrapper, which just passes its arguments straight through:
+
+```bash
+./bin/migrate-secrets-to-1password.sh CLICKUP_API_TOKEN SLITE_API_TOKEN cf-tunnel-tshallandale-prod-id cf-tunnel-tshallandale-prod-secret cf-tunnel-tshallandale-stg-id cf-tunnel-tshallandale-stg-secret
+```
+
+(those six were this repo's original known secrets — just an example, not a hardcoded
+list anymore). For a one-off future token, just call `secret-migrate MY_NEW_TOKEN`
+straight from the shell.
+
 It requires the 1Password desktop app's CLI integration to be enabled (Settings ->
-Developer -> "Integrate with 1Password CLI"), reads known secrets out of Keychain, and
-creates/updates matching items in the `Private` vault. It never prints secret values.
-Existing scripts need no further changes — `get-secret` picks up 1Password automatically
-once the item exists, and still falls back to Keychain for anything not yet migrated.
+Developer -> "Integrate with 1Password CLI"), reads each named secret out of Keychain,
+and creates/updates a matching item in the `Private` vault. It never prints secret
+values. Existing scripts need no further changes — `get-secret` picks up 1Password
+automatically once the item exists, and still falls back to Keychain for anything not
+yet migrated.
 
 ### 5. `auto-nvm.sh` - Automatic Node Version Manager
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,35 @@ The script will:
 5. Clean up empty directories if no files were moved
 6. Provide detailed feedback of all operations
 
-### 4. `auto-nvm.sh` - Automatic Node Version Manager
+### 4. `get-secret` (in `utils.sh`) - Secret Resolution Helper
+
+Resolves a named secret for scripts that need API tokens or service credentials
+(e.g. `cf-tunnel.sh`).
+
+#### Resolution order
+
+1. **1Password CLI** — `op read "op://Private/<name>/password"`
+2. **macOS Keychain** (fallback) — `security find-generic-password -s "<name>" -a "$USER" -w`
+
+If neither backend has the secret, it prints setup instructions for both and returns 1.
+Set `SECRETS_DEBUG=1` to log (to stderr) which backend served a given secret; the happy
+path is otherwise silent so it stays script-composable (`token="$(get-secret NAME)"`).
+
+#### Migrating existing Keychain secrets to 1Password
+
+Run once, interactively, by hand:
+
+```bash
+./bin/migrate-secrets-to-1password.sh
+```
+
+It requires the 1Password desktop app's CLI integration to be enabled (Settings ->
+Developer -> "Integrate with 1Password CLI"), reads known secrets out of Keychain, and
+creates/updates matching items in the `Private` vault. It never prints secret values.
+Existing scripts need no further changes — `get-secret` picks up 1Password automatically
+once the item exists, and still falls back to Keychain for anything not yet migrated.
+
+### 5. `auto-nvm.sh` - Automatic Node Version Manager
 
 Automatically switches Node.js versions when changing directories based on `.nvmrc` files.
 

--- a/bin/migrate-secrets-to-1password.sh
+++ b/bin/migrate-secrets-to-1password.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+#
+# One-time migration: copy secrets from macOS Keychain into 1Password (Private vault).
+# Run this yourself — it handles secret values, so it is never run by an automated agent.
+#
+# For each known keychain service name, reads the value from Keychain (never printed)
+# and creates or updates a matching 1Password item (category=password, vault=Private,
+# value stored in the `password` field). After migrating, get-secret() in src/utils.sh
+# will read from 1Password first and fall back to Keychain automatically — nothing else
+# to change.
+
+set -euo pipefail
+
+VAULT="Private"
+
+SERVICE_NAMES=(
+    "CLICKUP_API_TOKEN"
+    "SLITE_API_TOKEN"
+    "cf-tunnel-tshallandale-prod-id"
+    "cf-tunnel-tshallandale-prod-secret"
+    "cf-tunnel-tshallandale-stg-id"
+    "cf-tunnel-tshallandale-stg-secret"
+)
+
+created=()
+updated=()
+skipped=()
+
+echo "Checking 1Password CLI access..."
+if ! op account list >/dev/null 2>&1; then
+    echo "ERROR: 'op account list' failed. The 1Password CLI is not integrated with your desktop app." >&2
+    echo "Enable it in the 1Password app: Settings -> Developer -> \"Integrate with 1Password CLI\", then re-run this script." >&2
+    exit 1
+fi
+echo "1Password CLI OK."
+echo
+
+for name in "${SERVICE_NAMES[@]}"; do
+    echo "==> ${name}"
+
+    value="$(security find-generic-password -s "$name" -a "$USER" -w 2>/dev/null || true)"
+    if [[ -z "$value" ]]; then
+        echo "    skip: not found in Keychain (service: ${name}, account: ${USER})"
+        skipped+=("$name")
+        continue
+    fi
+
+    if op item get "$name" --vault "$VAULT" >/dev/null 2>&1; then
+        if op item edit "$name" --vault "$VAULT" "password=${value}" >/dev/null 2>&1; then
+            echo "    updated existing 1Password item"
+            updated+=("$name")
+        else
+            echo "    ERROR: failed to update 1Password item" >&2
+            skipped+=("$name")
+        fi
+    else
+        if op item create --category=password --title="$name" --vault="$VAULT" "password=${value}" >/dev/null 2>&1; then
+            echo "    created new 1Password item"
+            created+=("$name")
+        else
+            echo "    ERROR: failed to create 1Password item" >&2
+            skipped+=("$name")
+        fi
+    fi
+
+    unset value
+done
+
+echo
+echo "=== Summary ==="
+echo "Created (${#created[@]}): ${created[*]:-none}"
+echo "Updated (${#updated[@]}): ${updated[*]:-none}"
+echo "Skipped (${#skipped[@]}): ${skipped[*]:-none}"
+echo
+echo "Note: no secret values were printed above. Verify with, e.g.:"
+echo "  op read \"op://${VAULT}/CLICKUP_API_TOKEN/password\" | wc -c"

--- a/bin/migrate-secrets-to-1password.sh
+++ b/bin/migrate-secrets-to-1password.sh
@@ -1,76 +1,21 @@
 #!/bin/bash
 #
-# One-time migration: copy secrets from macOS Keychain into 1Password (Private vault).
-# Run this yourself — it handles secret values, so it is never run by an automated agent.
+# One-time (or one-off) migration: copy secrets from macOS Keychain into 1Password
+# (Private vault). Run this yourself — it handles secret values, so it is never run
+# by an automated agent.
 #
-# For each known keychain service name, reads the value from Keychain (never printed)
-# and creates or updates a matching 1Password item (category=password, vault=Private,
-# value stored in the `password` field). After migrating, get-secret() in src/utils.sh
-# will read from 1Password first and fall back to Keychain automatically — nothing else
-# to change.
+# Thin wrapper around secret-migrate() in src/utils.sh — pass the Keychain service
+# name(s) you want migrated. After migrating, get-secret() in the same file will
+# read them from 1Password first and fall back to Keychain automatically — nothing
+# else to change.
+#
+# Usage:
+#   ./bin/migrate-secrets-to-1password.sh CLICKUP_API_TOKEN SLITE_API_TOKEN ...
 
 set -euo pipefail
 
-VAULT="Private"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+# shellcheck source=../src/utils.sh
+source "${SCRIPT_DIR}/../src/utils.sh"
 
-SERVICE_NAMES=(
-    "CLICKUP_API_TOKEN"
-    "SLITE_API_TOKEN"
-    "cf-tunnel-tshallandale-prod-id"
-    "cf-tunnel-tshallandale-prod-secret"
-    "cf-tunnel-tshallandale-stg-id"
-    "cf-tunnel-tshallandale-stg-secret"
-)
-
-created=()
-updated=()
-skipped=()
-
-echo "Checking 1Password CLI access..."
-if ! op account list >/dev/null 2>&1; then
-    echo "ERROR: 'op account list' failed. The 1Password CLI is not integrated with your desktop app." >&2
-    echo "Enable it in the 1Password app: Settings -> Developer -> \"Integrate with 1Password CLI\", then re-run this script." >&2
-    exit 1
-fi
-echo "1Password CLI OK."
-echo
-
-for name in "${SERVICE_NAMES[@]}"; do
-    echo "==> ${name}"
-
-    value="$(security find-generic-password -s "$name" -a "$USER" -w 2>/dev/null || true)"
-    if [[ -z "$value" ]]; then
-        echo "    skip: not found in Keychain (service: ${name}, account: ${USER})"
-        skipped+=("$name")
-        continue
-    fi
-
-    if op item get "$name" --vault "$VAULT" >/dev/null 2>&1; then
-        if op item edit "$name" --vault "$VAULT" "password=${value}" >/dev/null 2>&1; then
-            echo "    updated existing 1Password item"
-            updated+=("$name")
-        else
-            echo "    ERROR: failed to update 1Password item" >&2
-            skipped+=("$name")
-        fi
-    else
-        if op item create --category=password --title="$name" --vault="$VAULT" "password=${value}" >/dev/null 2>&1; then
-            echo "    created new 1Password item"
-            created+=("$name")
-        else
-            echo "    ERROR: failed to create 1Password item" >&2
-            skipped+=("$name")
-        fi
-    fi
-
-    unset value
-done
-
-echo
-echo "=== Summary ==="
-echo "Created (${#created[@]}): ${created[*]:-none}"
-echo "Updated (${#updated[@]}): ${updated[*]:-none}"
-echo "Skipped (${#skipped[@]}): ${skipped[*]:-none}"
-echo
-echo "Note: no secret values were printed above. Verify with, e.g.:"
-echo "  op read \"op://${VAULT}/CLICKUP_API_TOKEN/password\" | wc -c"
+secret-migrate "$@"

--- a/src/cf-tunnel.sh
+++ b/src/cf-tunnel.sh
@@ -13,17 +13,13 @@ cf-tunnel() {
     local keychain_secret="${CF_TUNNEL_KEYCHAIN_SECRET:?CF_TUNNEL_KEYCHAIN_SECRET is not set}"
 
     local token_id token_secret
-    token_id="$(security find-generic-password -s "$keychain_id" -a "$USER" -w 2>/dev/null)"
-    if [[ -z "$token_id" ]]; then
-        log "ERROR" "Service token ID not found in Keychain (service: ${keychain_id})"
-        log "INFO" "Add it with: security add-generic-password -s \"${keychain_id}\" -a \"\$USER\" -w \"<your-token-id>\""
+    if ! token_id="$(get-secret "$keychain_id")"; then
+        log "ERROR" "Could not resolve service token ID (name: ${keychain_id})"
         return 1
     fi
 
-    token_secret="$(security find-generic-password -s "$keychain_secret" -a "$USER" -w 2>/dev/null)"
-    if [[ -z "$token_secret" ]]; then
-        log "ERROR" "Service token secret not found in Keychain (service: ${keychain_secret})"
-        log "INFO" "Add it with: security add-generic-password -s \"${keychain_secret}\" -a \"\$USER\" -w \"<your-token-secret>\""
+    if ! token_secret="$(get-secret "$keychain_secret")"; then
+        log "ERROR" "Could not resolve service token secret (name: ${keychain_secret})"
         return 1
     fi
 

--- a/src/utils.sh
+++ b/src/utils.sh
@@ -140,6 +140,33 @@ setup_directory_completion() {
     fi
 }
 
+# Secret resolution: 1Password CLI first, macOS Keychain as fallback.
+# Usage: get-secret <name>   (prints the secret to stdout; returns 1 if not found anywhere)
+# Set SECRETS_DEBUG=1 to log (to stderr) which backend served the secret.
+get-secret() {
+    local name="${1:?Usage: get-secret <name>}"
+    local value
+
+    value="$(op read "op://Private/${name}/password" 2>/dev/null)"
+    if [[ -n "$value" ]]; then
+        [[ -n "$SECRETS_DEBUG" ]] && log "DEBUG" "get-secret: served '${name}' from 1Password" >&2
+        printf '%s' "$value"
+        return 0
+    fi
+
+    value="$(security find-generic-password -s "$name" -a "$USER" -w 2>/dev/null)"
+    if [[ -n "$value" ]]; then
+        [[ -n "$SECRETS_DEBUG" ]] && log "DEBUG" "get-secret: served '${name}' from macOS Keychain (fallback)" >&2
+        printf '%s' "$value"
+        return 0
+    fi
+
+    log "ERROR" "Secret '${name}' not found in 1Password or Keychain" >&2
+    log "INFO" "Add it to 1Password with: op item create --category=password --title=\"${name}\" --vault=Private password=\"<value>\"" >&2
+    log "INFO" "Or add it to Keychain with: security add-generic-password -s \"${name}\" -a \"\$USER\" -w \"<value>\"" >&2
+    return 1
+}
+
 load-env() {
     local filename="${1:-.env}"
     local caller_dir

--- a/src/utils.sh
+++ b/src/utils.sh
@@ -167,6 +167,77 @@ get-secret() {
     return 1
 }
 
+# Migrate one or more secrets from macOS Keychain into 1Password (Private vault).
+# Usage: secret-migrate <name> [<name>...]
+# For each name: reads it from Keychain, then creates or updates a matching
+# 1Password item (category=password, vault=Private, value in the `password` field).
+# Never prints secret values. Requires the 1Password CLI to be integrated with the
+# desktop app (Settings -> Developer -> "Integrate with 1Password CLI").
+secret-migrate() {
+    if [[ $# -eq 0 ]]; then
+        echo "Usage: secret-migrate <name> [<name>...]" >&2
+        echo "  Reads each name from macOS Keychain and creates/updates a matching" >&2
+        echo "  1Password item (Private vault, password field). Never prints values." >&2
+        echo "Example (one-off future tokens, straight from the shell):" >&2
+        echo "  secret-migrate CLICKUP_API_TOKEN SLITE_API_TOKEN cf-tunnel-tshallandale-prod-id cf-tunnel-tshallandale-prod-secret cf-tunnel-tshallandale-stg-id cf-tunnel-tshallandale-stg-secret" >&2
+        return 1
+    fi
+
+    local vault="Private"
+
+    echo "Checking 1Password CLI access..."
+    if ! op account list >/dev/null 2>&1; then
+        log "ERROR" "'op account list' failed. The 1Password CLI is not integrated with your desktop app." >&2
+        log "INFO" "Enable it in the 1Password app: Settings -> Developer -> \"Integrate with 1Password CLI\", then re-run." >&2
+        return 1
+    fi
+    echo "1Password CLI OK."
+    echo
+
+    local created=() updated=() skipped=()
+    local name value
+
+    for name in "$@"; do
+        echo "==> ${name}"
+
+        value="$(security find-generic-password -s "$name" -a "$USER" -w 2>/dev/null || true)"
+        if [[ -z "$value" ]]; then
+            echo "    skip: not found in Keychain (service: ${name}, account: ${USER})"
+            skipped+=("$name")
+            continue
+        fi
+
+        if op item get "$name" --vault "$vault" >/dev/null 2>&1; then
+            if op item edit "$name" --vault "$vault" "password=${value}" >/dev/null 2>&1; then
+                echo "    updated existing 1Password item"
+                updated+=("$name")
+            else
+                echo "    ERROR: failed to update 1Password item" >&2
+                skipped+=("$name")
+            fi
+        else
+            if op item create --category=password --title="$name" --vault="$vault" "password=${value}" >/dev/null 2>&1; then
+                echo "    created new 1Password item"
+                created+=("$name")
+            else
+                echo "    ERROR: failed to create 1Password item" >&2
+                skipped+=("$name")
+            fi
+        fi
+
+        unset value
+    done
+
+    echo
+    echo "=== Summary ==="
+    echo "Created (${#created[@]}): ${created[*]:-none}"
+    echo "Updated (${#updated[@]}): ${updated[*]:-none}"
+    echo "Skipped (${#skipped[@]}): ${skipped[*]:-none}"
+    echo
+    echo "Note: no secret values were printed above. Verify with, e.g.:"
+    echo "  op read \"op://${vault}/<name>/password\" | wc -c"
+}
+
 load-env() {
     local filename="${1:-.env}"
     local caller_dir


### PR DESCRIPTION
## What

Adds a `get-secret <name>` helper that resolves secrets from 1Password CLI first (`op://Private/<name>/password`) and falls back to the macOS Keychain, and refactors `cf-tunnel` onto it. Includes a one-time `bin/migrate-secrets-to-1password.sh` to copy existing Keychain items into the vault.

## Why

Keychain items are device-local: every machine migration needs a manual export/import ceremony. With secrets in 1Password, a new machine only needs `op` signed in — no per-token setup. Fallback keeps everything working when 1Password is locked/absent, so this is non-breaking.

## Notes

- `SECRETS_DEBUG=1` logs which backend served a secret (stderr only).
- Migration script never prints values; already run locally (6 items created).
- Keychain items intentionally kept — other tooling still reads them directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)